### PR TITLE
Feature/117 app log

### DIFF
--- a/BeMyPlan/BeMyPlan.xcodeproj/project.pbxproj
+++ b/BeMyPlan/BeMyPlan.xcodeproj/project.pbxproj
@@ -170,6 +170,12 @@
 		FD4C86B8278C7A7200D37A2D /* Payment.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = FD4C86B7278C7A7200D37A2D /* Payment.storyboard */; };
 		FD4C86BA278C7A8400D37A2D /* PaymentSelectVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD4C86B9278C7A8400D37A2D /* PaymentSelectVC.swift */; };
 		FD4C86BE278C9AF900D37A2D /* PaymentCompleteVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD4C86BD278C9AF900D37A2D /* PaymentCompleteVC.swift */; };
+		FD568E6F27CFE4ED0078D23C /* AnalyticsType.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD568E6E27CFE4ED0078D23C /* AnalyticsType.swift */; };
+		FD568E7127CFE6CF0078D23C /* FirebaseServiceProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD568E7027CFE6CF0078D23C /* FirebaseServiceProtocol.swift */; };
+		FD568E7327CFE6DF0078D23C /* AppLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD568E7227CFE6DF0078D23C /* AppLog.swift */; };
+		FD568E7627CFE7270078D23C /* LogEventType.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD568E7527CFE7270078D23C /* LogEventType.swift */; };
+		FD568E7927CFE80E0078D23C /* RuntimeProviderType.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD568E7827CFE80E0078D23C /* RuntimeProviderType.swift */; };
+		FD568E7B27CFE8200078D23C /* FirebaseAnalyticsProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD568E7A27CFE8200078D23C /* FirebaseAnalyticsProvider.swift */; };
 		FD5D730F27A46BAB002DE484 /* PlanPreviewViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD5D730E27A46BAB002DE484 /* PlanPreviewViewModel.swift */; };
 		FD5D731127A48491002DE484 /* ViewModelType.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD5D731027A48491002DE484 /* ViewModelType.swift */; };
 		FD61AFA327902C7A00D39F47 /* PlanDetailSelectDayView.xib in Resources */ = {isa = PBXBuildFile; fileRef = FD61AFA227902C7A00D39F47 /* PlanDetailSelectDayView.xib */; };
@@ -432,6 +438,12 @@
 		FD4C86B7278C7A7200D37A2D /* Payment.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = Payment.storyboard; sourceTree = "<group>"; };
 		FD4C86B9278C7A8400D37A2D /* PaymentSelectVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentSelectVC.swift; sourceTree = "<group>"; };
 		FD4C86BD278C9AF900D37A2D /* PaymentCompleteVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentCompleteVC.swift; sourceTree = "<group>"; };
+		FD568E6E27CFE4ED0078D23C /* AnalyticsType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsType.swift; sourceTree = "<group>"; };
+		FD568E7027CFE6CF0078D23C /* FirebaseServiceProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirebaseServiceProtocol.swift; sourceTree = "<group>"; };
+		FD568E7227CFE6DF0078D23C /* AppLog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppLog.swift; sourceTree = "<group>"; };
+		FD568E7527CFE7270078D23C /* LogEventType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogEventType.swift; sourceTree = "<group>"; };
+		FD568E7827CFE80E0078D23C /* RuntimeProviderType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RuntimeProviderType.swift; sourceTree = "<group>"; };
+		FD568E7A27CFE8200078D23C /* FirebaseAnalyticsProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirebaseAnalyticsProvider.swift; sourceTree = "<group>"; };
 		FD5D730E27A46BAB002DE484 /* PlanPreviewViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlanPreviewViewModel.swift; sourceTree = "<group>"; };
 		FD5D731027A48491002DE484 /* ViewModelType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewModelType.swift; sourceTree = "<group>"; };
 		FD61AFA227902C7A00D39F47 /* PlanDetailSelectDayView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = PlanDetailSelectDayView.xib; sourceTree = "<group>"; };
@@ -1093,6 +1105,7 @@
 		FD3211C527843F5E007D63D5 /* Global */ = {
 			isa = PBXGroup;
 			children = (
+				FD568E6C27CFE3FD0078D23C /* Manager */,
 				FD09DE2527857DD6006DA050 /* Model */,
 				FD09DDEE278577BA006DA050 /* Network */,
 				FD09DE0127857927006DA050 /* Utils */,
@@ -1249,6 +1262,43 @@
 				FD4C86BD278C9AF900D37A2D /* PaymentCompleteVC.swift */,
 			);
 			path = Payment;
+			sourceTree = "<group>";
+		};
+		FD568E6C27CFE3FD0078D23C /* Manager */ = {
+			isa = PBXGroup;
+			children = (
+				FD568E6D27CFE4100078D23C /* Analytics */,
+			);
+			path = Manager;
+			sourceTree = "<group>";
+		};
+		FD568E6D27CFE4100078D23C /* Analytics */ = {
+			isa = PBXGroup;
+			children = (
+				FD568E7727CFE7DD0078D23C /* Provider */,
+				FD568E7427CFE71B0078D23C /* EventType */,
+				FD568E6E27CFE4ED0078D23C /* AnalyticsType.swift */,
+				FD568E7227CFE6DF0078D23C /* AppLog.swift */,
+				FD568E7027CFE6CF0078D23C /* FirebaseServiceProtocol.swift */,
+			);
+			path = Analytics;
+			sourceTree = "<group>";
+		};
+		FD568E7427CFE71B0078D23C /* EventType */ = {
+			isa = PBXGroup;
+			children = (
+				FD568E7527CFE7270078D23C /* LogEventType.swift */,
+			);
+			path = EventType;
+			sourceTree = "<group>";
+		};
+		FD568E7727CFE7DD0078D23C /* Provider */ = {
+			isa = PBXGroup;
+			children = (
+				FD568E7827CFE80E0078D23C /* RuntimeProviderType.swift */,
+				FD568E7A27CFE8200078D23C /* FirebaseAnalyticsProvider.swift */,
+			);
+			path = Provider;
 			sourceTree = "<group>";
 		};
 		FD93027B27A3EC3700341C2A /* Repository */ = {
@@ -1699,6 +1749,7 @@
 				F266412E2788262800CCC751 /* MainListData.swift in Sources */,
 				FD20C610278EBF2800AC6E34 /* MyPlanBuyData.swift in Sources */,
 				FD09DDF1278577CF006DA050 /* BaseService.swift in Sources */,
+				FD568E7927CFE80E0078D23C /* RuntimeProviderType.swift in Sources */,
 				FDF980D22786D2EB0009A14E /* TravelSpotVC.swift in Sources */,
 				FD008829278FE94C00C194B5 /* PlanDetailInfoPhotoCVC.swift in Sources */,
 				FD3566512792AF2C0082B4CE /* ScrapEmptyCotainerCVC.swift in Sources */,
@@ -1711,7 +1762,9 @@
 				FD09DE0727857971006DA050 /* calculateTopInset.swift in Sources */,
 				FDF980E32786E7E90009A14E /* BaseContainerView.swift in Sources */,
 				FD4C86B0278BD17F00D37A2D /* setImage.swift in Sources */,
+				FD568E7B27CFE8200078D23C /* FirebaseAnalyticsProvider.swift in Sources */,
 				FD20C612278EC29600AC6E34 /* setTextLineHeight + UILabel.swift in Sources */,
+				FD568E7327CFE6DF0078D23C /* AppLog.swift in Sources */,
 				F250440D2799D02900791AB7 /* AuthDataModel.swift in Sources */,
 				FDF980D42786D2F60009A14E /* PlanListVC.swift in Sources */,
 				FD2D9C5A2796FDA400688A42 /* UITableViewCell + Animator.swift in Sources */,
@@ -1760,6 +1813,7 @@
 				FD2D4DB9278D3DCE002084B9 /* PlanDetailInformationTVC.swift in Sources */,
 				FD20C60B278EBBB500AC6E34 /* MyPlanBuyContentCVC.swift in Sources */,
 				FDF981022788D49C0009A14E /* PlanPreviewWriterTVC.swift in Sources */,
+				FD568E7127CFE6CF0078D23C /* FirebaseServiceProtocol.swift in Sources */,
 				523C70FF2799DCC10073371D /* ScrapEmptyService.swift in Sources */,
 				FDF981042788D4AB0009A14E /* PlanPreviewDescriptionTVC.swift in Sources */,
 				FDA2063427C40FF6001A371D /* PlanDetailViewModel.swift in Sources */,
@@ -1786,6 +1840,7 @@
 				FDF981062788D4C00009A14E /* PlanPreviewPhotoTVC.swift in Sources */,
 				FD1A78262795DA7100FB10AB /* showNetworkErr + UIViewController.swift in Sources */,
 				FD09DE1E27857CDC006DA050 /* HomeVC.swift in Sources */,
+				FD568E6F27CFE4ED0078D23C /* AnalyticsType.swift in Sources */,
 				FD5D731127A48491002DE484 /* ViewModelType.swift in Sources */,
 				FD61AFDC2791DC6E00D39F47 /* UINavigation + Extension.swift in Sources */,
 				FD20C623278EF11000AC6E34 /* MyPlanWithdrawVC.swift in Sources */,
@@ -1813,6 +1868,7 @@
 				FD09DE1327857AE1006DA050 /* successCatch + Result.swift in Sources */,
 				F261EC7927873A7D00AF094F /* MainCardCVC.swift in Sources */,
 				FD09DDF727857841006DA050 /* UITableViewRegisterable.swift in Sources */,
+				FD568E7627CFE7270078D23C /* LogEventType.swift in Sources */,
 				F261EC7C27873D3C00AF094F /* MainCardData.swift in Sources */,
 				F294EC28278EBC2C001069F8 /* LoginVC + KakaoLogin.swift in Sources */,
 				FD09DE0D278579CC006DA050 /* showNetworkAlert.swift in Sources */,

--- a/BeMyPlan/BeMyPlan/Global/Manager/Analytics/AnalyticsType.swift
+++ b/BeMyPlan/BeMyPlan/Global/Manager/Analytics/AnalyticsType.swift
@@ -1,0 +1,41 @@
+//
+//  AnalyticsType.swift
+//  BeMyPlan
+//
+//  Created by 송지훈 on 2022/03/03.
+//
+
+import Foundation
+
+public protocol AnalyticsType {
+  associatedtype Event: EventType
+  func register(provider: ProviderType)
+  func log(_ event: Event)
+}
+
+public protocol ProviderType {
+  func log(_ eventName: String, parameters: [String: Any]?)
+}
+
+public protocol EventType {
+  func name(for provider: ProviderType) -> String?
+  func parameters(for provider: ProviderType) -> [String: Any]?
+}
+
+open class AnalyticsManager<Event: EventType>: AnalyticsType {
+  private(set) open var providers: [ProviderType] = []
+
+  public init() {}
+
+  open func register(provider: ProviderType) {
+    self.providers.append(provider)
+  }
+
+  open func log(_ event: Event) {
+    for provider in self.providers {
+      guard let eventName = event.name(for: provider) else { continue }
+      let parameters = event.parameters(for: provider)
+      provider.log(eventName, parameters: parameters)
+    }
+  }
+}

--- a/BeMyPlan/BeMyPlan/Global/Manager/Analytics/AppLog.swift
+++ b/BeMyPlan/BeMyPlan/Global/Manager/Analytics/AppLog.swift
@@ -1,0 +1,48 @@
+//
+//  AppLog.swift
+//  BeMyPlan
+//
+//  Created by 송지훈 on 2022/03/03.
+//
+
+import Foundation
+import FirebaseCore
+import FirebaseAnalytics
+import FirebaseCrashlytics
+
+enum LogProviderType: String {
+  case firebaseAnalyticsProvider = "FirebaseAnalyticsProvider"
+}
+
+class AppLog {
+  
+  private static var crashlyticsService: CrashlyticsServiceProtocol.Type = Crashlytics.self
+  private static var configureService: FirebaseConfigureServiceProtocol.Type = FirebaseApp.self
+  private static var analyticsService: FirebaseAnalyticsServiceProtocol.Type = Analytics.self
+  private static let analytics = AnalyticsManager<LogEventType>()
+  
+  static func configure() {
+    self.configureService.configure()
+    self.analytics.register(provider: FirebaseAnalyticsProvider())
+  }
+  
+  static func setFirebaseUserProperty() {
+    let userIdx = String(UserDefaults.standard.integer(forKey: "userIdx"))
+    analyticsService.setUserProperty(userIdx, forName: "userIdx")
+  }
+  
+  static func log(at providerType: ProviderType.Type, _ event: LogEventType) {
+      self.analytics.log(at: providerType, event)
+  }
+}
+
+extension AnalyticsManager {
+  func log(at providerType: ProviderType.Type, _ event: Event) {
+    for provider in self.providers {
+      guard type(of: provider.self) == providerType.self else { continue }
+      guard let eventName = event.name(for: provider) else { continue }
+      let parameters = event.parameters(for: provider)
+      provider.log(eventName, parameters: parameters)
+    }
+  }
+}

--- a/BeMyPlan/BeMyPlan/Global/Manager/Analytics/EventType/LogEventType.swift
+++ b/BeMyPlan/BeMyPlan/Global/Manager/Analytics/EventType/LogEventType.swift
@@ -166,34 +166,33 @@ extension LogEventType: EventType {
 
 extension LogEventType {
   enum LoginSource: String {
-    case kakao = "kakao"
-    case apple = "apple"
-    case guest = "guest"
-  }
+    case kakao
+    case apple
+    case guest  }
   
   enum TabSource: String {
-    case home = "home"
-    case travelSpot = "travelSpot"
-    case scrap = "scrap"
-    case myPlan = "myPlan"
+    case home
+    case travelSpot
+    case scrap
+    case myPlan
   }
   
   enum ViewSource: String {
-    case scrapView = "scrapView"
-    case travelListView = "travelListView"
-    case planPreview = "planPreview"
-    case PlanDetail = "planDetail"
-    case myPlanView = "myPlanView"
+    case scrapView
+    case travelListView
+    case planPreview
+    case PlanDetail
+    case myPlanView
   }
   
   enum PaymentSource: String{
-    case kakaoPay = "kakaoPay"
-    case naverPay = "naverPay"
-    case toss = "toss"
+    case kakaoPay
+    case naverPay
+    case toss
   }
   
   enum MapSource: String{
-    case kakaoMap = "kakaoMap"
-    case naverMap = "naverMap"
+    case kakaoMap
+    case naverMap
   }
 }

--- a/BeMyPlan/BeMyPlan/Global/Manager/Analytics/EventType/LogEventType.swift
+++ b/BeMyPlan/BeMyPlan/Global/Manager/Analytics/EventType/LogEventType.swift
@@ -12,23 +12,31 @@ import Foundation
  앱 삭제 --> 추적 불가능
  
  로그인
+ 
+ 
  스크랩 눌러서 로그인
  구매하기 눌러서 로그인
  마이플랜에서 로그인
  
- --> login + type
+ --> login + type + userID
+ 
+  로그아웃
+ --> logout + userID
+ 
+ 
+ 
  
  
  메인홈 콘텐츠 보기
  여행지탭에 들어가 콘텐츠 리스트 보기
  콘텐츠 선택
  스크랩한 여행 일정 보기
- -->  clickPlanDetail + case
+ -->  clickPlanDetail + case + postID
 
  
  여행 일정 스크랩 하기
  여행 일정 스크랩 제거
- --> scrap
+ --> scrap + postID
  
  
  구매하기 누름
@@ -38,54 +46,128 @@ import Foundation
 
  */
 enum LogEventType {
+  // 1. 앱 최초 실행
   case appFirstOpen
-  case signUp
-  case clickHomePlanDetail
-  case clickSpotList
-  case clickPlanDetailInSpotList
   
+  // 2. 온보딩
+  case onboardingFirstOpen
+  case onboardingEnd
   
+  // 3. 로그인
+  case signin(source: LoginSource)
   
+  // 4. 회원가입
+  case signupNickname(source: LoginSource)
+  case signupEmail(source: LoginSource)
+  case signupComplete(source: LoginSource)
   
-  case addSubjectTimetable(subjectIdx: String, subjectName: String)
-  case enterCommunicationRoom(subjectIdx: String)
-  case sendCommunicationMessage(subjectIdx: String, messageType: String)
-  case loadCommunityArticle(postIdx: String)
-  case writeCommunityArticle(boardIdx: String)
-  case writeCommunityArticleComment(postIdx: String)
-  case loadCommunityQnA(qnaIdx: String)
-  case writeCommunityQnA(tagIdx: String)
-  case writeCommunityQnaAnswer(qnaIdx: String)
-  case clickBottomTabHome
-  case clickBottomTabClass
-  case clickBottomTabCommunity
-  case clickBottomTabQna
-  case clickBottomTabMypage
-  case clickHomeMajorDept
-  case clickCommunityMajorDept
+  // 5. 탭바 클릭 액션
+  case clickTab(source: TabSource)
+  
+  // 6. 홈탭 내 액션
+  case clickHomeRecentPlanList
+  case clickHomeRecommendPlanList
+  
+  // 7. 여행지 뷰
+  case clickOpenedTravelSpot(spot: String)
+  case clickClosedTravelSpot(spot: String)
+  
+  // 8. 둘러보기 -> 로그인뷰 띄워지는 경우
+  case showLoginPage(source: ViewSource)
+
+  // 9. 여행 일정 클릭
+  case clickTravelPlan(source :ViewSource,
+                       postIdx: String)
+  
+  // 10. 스크랩 액션
+  case scrapTravelPlan(source: ViewSource,
+                       postIdx: String)
+  case scrapCancelTravelPlan(source: ViewSource,
+                             postIdx: String)
+  
+  // 11.결제 뷰
+  case closePaymentView
+  case clickPaymentMethod(source: PaymentSource)
+  
+  // 12. 결제 완료 뷰
+  case closePaymentCompleteView
+  case clickPlanDetailView(postIdx: String)
+  
+  // 13. 결제 전 여행일정
+  case clickPlanDetailExample
+  
+  // 14. 결제 후 여행일정
+  case clickAddressCopy(postIdx: String)
+  case moveMapApplication(source: MapSource)
+  case alertNoMapApplication
+  
+  // 15. 작성자 이름 클릭
+  case clickEditorName(source: ViewSource)
+  
+  // 16. 회원 유입 및 이탈
+  case enterForeGround
+  case enterBackGround
+  case logout
+  case withdrawal
+  
+
 }
 
 extension LogEventType: EventType {
   func name(for provider: ProviderType) -> String? {
     switch self {
-      case .appFirstOpen: return "Appsflyer_app_open"
-      case .signUp: return "Appsflyer_sign_up"
-      case .addSubjectTimetable: return "timetable_add_subject"
-      case .enterCommunicationRoom: return "lecture_entrance"
-      case .sendCommunicationMessage: return "lecture_send_message"
-      case .loadCommunityArticle: return "community_article_load"
-      case .writeCommunityArticle: return "community_article_write"
-      case .writeCommunityArticleComment: return "community_article_comment_write"
-      case .loadCommunityQnA: return "community_qna_load"
-      case .writeCommunityQnA: return "community_qna_write"
-      case .writeCommunityQnaAnswer: return "community_qna_write_answer"
-      case .clickBottomTabHome: return "event_click_bottom_tab_home"
-      case .clickBottomTabClass: return "event_click_bottom_tab_class"
-      case .clickBottomTabCommunity: return "event_click_bottom_tab_community"
-      case .clickBottomTabQna: return "event_click_bottom_tab_qna"
-      case .clickBottomTabMypage: return "event_click_bottom_tab_mypage"
-      case .clickHomeMajorDept: return "event_click_home_major_dept"
-      case .clickCommunityMajorDept: return "event_click_community_major_dept"
+      case .appFirstOpen: return "event_firebase_first_open"
+      case .onboardingFirstOpen: return "event_onboarding_first_open"
+      case .onboardingEnd: return "event_onboarding_complete"
+      case .signin: return "event_signin_click"
+      case .signupNickname: return "event_signup_nickname"
+      case .signupEmail: return "onboarding_first_open"
+      case .signupComplete: return "onboarding_first_open"
+      case .clickTab: return "onboarding_first_open"
+      case .clickHomeRecentPlanList: return "onboarding_first_open"
+      case .clickHomeRecommendPlanList: return "onboarding_first_open"
+      case .clickOpenedTravelSpot(spot: let spot): return "onboarding_first_open"
+        
+      case .clickClosedTravelSpot(spot: let spot): return "onboarding_first_open"
+        
+      case .showLoginPage(source: let source):
+        return "onboarding_first_open"
+        
+      case .clickTravelPlan(source: let source, postIdx: let postIdx):
+        return "onboarding_first_open"
+        
+      case .scrapTravelPlan(source: let source, postIdx: let postIdx):
+        return "onboarding_first_open"
+        
+      case .scrapCancelTravelPlan(source: let source, postIdx: let postIdx):
+        return "onboarding_first_open"
+        
+      case .closePaymentView: return "onboarding_first_open"
+        
+      case .clickPaymentMethod(source: let source): return "onboarding_first_open"
+        
+      case .closePaymentCompleteView: return "onboarding_first_open"
+        
+      case .clickPlanDetailView(postIdx: let postIdx): return "onboarding_first_open"
+        
+      case .clickPlanDetailExample: return "onboarding_first_open"
+        
+      case .clickAddressCopy(postIdx: let postIdx): return "onboarding_first_open"
+        
+      case .moveMapApplication(source: let source): return "onboarding_first_open"
+        
+      case .alertNoMapApplication: return "onboarding_first_open"
+        
+      case .clickEditorName(source: let source): return "onboarding_first_open"
+        
+      case .enterForeGround: return "onboarding_first_open"
+        
+      case .enterBackGround: return "onboarding_first_open"
+        
+      case .logout: return "onboarding_first_open"
+        
+      case .withdrawal: return "onboarding_first_open"
+        
     }
   }
   
@@ -95,28 +177,44 @@ extension LogEventType: EventType {
       "userIdx": String(UserDefaults.standard.integer(forKey: "userIdx"))
     ]
     switch self {
-      case let .addSubjectTimetable(subjectIdx, subjectName):
-        params["subjectIdx"] = subjectIdx
-        params["subjectName"] = subjectName
-      case let .enterCommunicationRoom(subjectIdx):
-        params["subjectIdx"] = subjectIdx
-      case let .sendCommunicationMessage(subjectIdx, messageType):
-        params["subjectIdx"] = subjectIdx
-        params["messageType"] = messageType
-      case let .loadCommunityArticle(postIdx):
-        params["postIdx"] = postIdx
-      case let .writeCommunityArticle(boardIdx):
-        params["boardIdx"] = boardIdx
-      case let .writeCommunityArticleComment(postIdx):
-        params["postIdx"] = postIdx
-      case let .loadCommunityQnA(qnaIdx):
-        params["qnaIdx"] = qnaIdx
-      case let .writeCommunityQnA(tagIdx):
-        params["tagIdx"] = tagIdx
-      case let .writeCommunityQnaAnswer(qnaIdx):
-        params["qnaIdx"] = qnaIdx
+
       default: break
     }
     return params
+  }
+}
+
+
+extension LogEventType {
+  enum LoginSource: String {
+    case kakao = "kakao"
+    case apple = "apple"
+    case guest = "guest"
+  }
+  
+  enum TabSource: String {
+    case home = "home"
+    case travelSpot = "travelSpot"
+    case scrap = "scrap"
+    case myPlan = "myPlan"
+  }
+  
+  enum ViewSource: String {
+    case scrapView = "scrapView"
+    case travelListView = "travelListView"
+    case planPreview = "planPreview"
+    case PlanDetail = "planDetail"
+    case myPlanView = "myPlanView"
+  }
+  
+  enum PaymentSource: String{
+    case kakaoPay = "kakaoPay"
+    case naverPay = "naverPay"
+    case toss = "toss"
+  }
+  
+  enum MapSource: String{
+    case kakaoMap = "kakaoMap"
+    case naverMap = "naverMap"
   }
 }

--- a/BeMyPlan/BeMyPlan/Global/Manager/Analytics/EventType/LogEventType.swift
+++ b/BeMyPlan/BeMyPlan/Global/Manager/Analytics/EventType/LogEventType.swift
@@ -175,8 +175,11 @@ extension LogEventType {
   }
   
   enum ViewSource: String {
+    case homeView
     case scrapView
+    case scrapRecommendView
     case travelListView
+    case planListView
     case planPreview
     case planDetail
     case myPlanView

--- a/BeMyPlan/BeMyPlan/Global/Manager/Analytics/EventType/LogEventType.swift
+++ b/BeMyPlan/BeMyPlan/Global/Manager/Analytics/EventType/LogEventType.swift
@@ -52,20 +52,20 @@ enum LogEventType {
   case clickPaymentMethod(source: PaymentSource)
   case clickPaymentButton(postIdx: String)
   
-  // 12. 결제 완료 뷰
+  // 12. 결제 완료 뷰 O
   case closePaymentCompleteView
   case clickPlanDetailViewInPayment(postIdx: String)
   
-  // 13. 결제 전 여행일정
+  // 13. 결제 전 여행일정 예시 O
   case clickPlanDetailExample
   
-  // 14. 결제 후 여행일정
-  case clickAddressCopy(postIdx: String)
-  case moveMapApplication(source: MapSource,postIdx: String)
+  // 14. 결제 후 여행일정 O
+  case clickAddressCopy
+  case moveMapApplication(source: MapSource)
   case alertNoMapApplication
   
-  // 15. 작성자 이름 클릭
-  case clickEditorName(source: ViewSource,postIdx: String)
+  // 15. 작성자 이름 클릭 O
+  case clickEditorName(source: ViewSource)
   
   // 16. 회원 유입 및 이탈
   case enterForeGround
@@ -145,17 +145,14 @@ extension LogEventType: EventType {
         params["paymentSource"] = paymentSource.rawValue
       
       case .clickPaymentButton(let postIdx),
-          .clickPlanDetailViewInPayment(let postIdx),
-          .clickAddressCopy(let postIdx):
+          .clickPlanDetailViewInPayment(let postIdx):
         params["postIdx"] = postIdx
         
-      case .moveMapApplication(let mapSource, let postIdx):
+      case .moveMapApplication(let mapSource):
         params["mapSource"] = mapSource
-        params["postIdx"] = postIdx
 
-      case .clickEditorName(let viewSource, let postIdx):
+      case .clickEditorName(let viewSource):
         params["viewSource"] = viewSource
-        params["postIdx"] = postIdx
 
       default: break
     }
@@ -181,7 +178,7 @@ extension LogEventType {
     case scrapView
     case travelListView
     case planPreview
-    case PlanDetail
+    case planDetail
     case myPlanView
   }
   

--- a/BeMyPlan/BeMyPlan/Global/Manager/Analytics/EventType/LogEventType.swift
+++ b/BeMyPlan/BeMyPlan/Global/Manager/Analytics/EventType/LogEventType.swift
@@ -7,44 +7,6 @@
 
 import Foundation
 
-/**
- 앱 설치 --> appFirstOpen
- 앱 삭제 --> 추적 불가능
- 
- 로그인
- 
- 
- 스크랩 눌러서 로그인
- 구매하기 눌러서 로그인
- 마이플랜에서 로그인
- 
- --> login + type + userID
- 
-  로그아웃
- --> logout + userID
- 
- 
- 
- 
- 
- 메인홈 콘텐츠 보기
- 여행지탭에 들어가 콘텐츠 리스트 보기
- 콘텐츠 선택
- 스크랩한 여행 일정 보기
- -->  clickPlanDetail + case + postID
-
- 
- 여행 일정 스크랩 하기
- 여행 일정 스크랩 제거
- --> scrap + postID
- 
- 
- 구매하기 누름
- 결제수단 선택
- 결제하기 누름
- 마이플랜에서 구매한 여행 일정 누름
-
- */
 enum LogEventType {
   // 1. 앱 최초 실행
   case appFirstOpen
@@ -88,86 +50,63 @@ enum LogEventType {
   // 11.결제 뷰
   case closePaymentView
   case clickPaymentMethod(source: PaymentSource)
+  case clickPaymentButton(postIdx: String)
   
   // 12. 결제 완료 뷰
   case closePaymentCompleteView
-  case clickPlanDetailView(postIdx: String)
+  case clickPlanDetailViewInPayment(postIdx: String)
   
   // 13. 결제 전 여행일정
   case clickPlanDetailExample
   
   // 14. 결제 후 여행일정
   case clickAddressCopy(postIdx: String)
-  case moveMapApplication(source: MapSource)
+  case moveMapApplication(source: MapSource,postIdx: String)
   case alertNoMapApplication
   
   // 15. 작성자 이름 클릭
-  case clickEditorName(source: ViewSource)
+  case clickEditorName(source: ViewSource,postIdx: String)
   
   // 16. 회원 유입 및 이탈
   case enterForeGround
   case enterBackGround
   case logout
   case withdrawal
-  
-
 }
 
 extension LogEventType: EventType {
   func name(for provider: ProviderType) -> String? {
     switch self {
-      case .appFirstOpen: return "event_firebase_first_open"
-      case .onboardingFirstOpen: return "event_onboarding_first_open"
-      case .onboardingEnd: return "event_onboarding_complete"
-      case .signin: return "event_signin_click"
-      case .signupNickname: return "event_signup_nickname"
-      case .signupEmail: return "onboarding_first_open"
-      case .signupComplete: return "onboarding_first_open"
-      case .clickTab: return "onboarding_first_open"
-      case .clickHomeRecentPlanList: return "onboarding_first_open"
-      case .clickHomeRecommendPlanList: return "onboarding_first_open"
-      case .clickOpenedTravelSpot(spot: let spot): return "onboarding_first_open"
-        
-      case .clickClosedTravelSpot(spot: let spot): return "onboarding_first_open"
-        
-      case .showLoginPage(source: let source):
-        return "onboarding_first_open"
-        
-      case .clickTravelPlan(source: let source, postIdx: let postIdx):
-        return "onboarding_first_open"
-        
-      case .scrapTravelPlan(source: let source, postIdx: let postIdx):
-        return "onboarding_first_open"
-        
-      case .scrapCancelTravelPlan(source: let source, postIdx: let postIdx):
-        return "onboarding_first_open"
-        
-      case .closePaymentView: return "onboarding_first_open"
-        
-      case .clickPaymentMethod(source: let source): return "onboarding_first_open"
-        
-      case .closePaymentCompleteView: return "onboarding_first_open"
-        
-      case .clickPlanDetailView(postIdx: let postIdx): return "onboarding_first_open"
-        
-      case .clickPlanDetailExample: return "onboarding_first_open"
-        
-      case .clickAddressCopy(postIdx: let postIdx): return "onboarding_first_open"
-        
-      case .moveMapApplication(source: let source): return "onboarding_first_open"
-        
-      case .alertNoMapApplication: return "onboarding_first_open"
-        
-      case .clickEditorName(source: let source): return "onboarding_first_open"
-        
-      case .enterForeGround: return "onboarding_first_open"
-        
-      case .enterBackGround: return "onboarding_first_open"
-        
-      case .logout: return "onboarding_first_open"
-        
-      case .withdrawal: return "onboarding_first_open"
-        
+      case .appFirstOpen:                 return "firebase_first_open"
+      case .onboardingFirstOpen:          return "onboarding_first_open"
+      case .onboardingEnd:                return "onboarding_complete"
+      case .signin:                       return "signin_click"
+      case .signupNickname:               return "signup_nickname"
+      case .signupEmail:                  return "signup_email"
+      case .signupComplete:               return "signup_complete"
+      case .clickTab:                     return "click_tab"
+      case .clickHomeRecentPlanList:      return "click_home_recent_list"
+      case .clickHomeRecommendPlanList:   return "click_home_recommend_list"
+      case .clickOpenedTravelSpot:        return "click_opened_travel_spot"
+      case .clickClosedTravelSpot:        return "click_closed_travel_spot"
+      case .showLoginPage:                return "move_login_page"
+      case .clickTravelPlan:              return "click_travel_plan"
+      case .scrapTravelPlan:              return "scrap_travel_plan"
+      case .scrapCancelTravelPlan:        return "scrap_cancel_travel_plan"
+      case .closePaymentView:             return "close_payment_view"
+      case .clickPaymentMethod:           return "click_payment_method"
+      case .clickPaymentButton:           return "click_payment_button"
+      case .closePaymentCompleteView:     return "close_payment_complete"
+      case .clickPlanDetailViewInPayment: return "move_plan_detail_view_in_payment"
+      case .clickPlanDetailExample:       return "click_plan_detail_example"
+      case .clickAddressCopy:             return "click_address_copy"
+      case .moveMapApplication:           return "move_map_application"
+      case .alertNoMapApplication:        return "alert_no_map_application"
+      case .clickEditorName:              return "click_editor_name"
+      case .enterForeGround:              return "enter_foreground"
+      case .enterBackGround:              return "enter_background"
+      case .logout:                       return "user_logout"
+      case .withdrawal:                   return "user_withdrawal"
     }
   }
   
@@ -177,6 +116,46 @@ extension LogEventType: EventType {
       "userIdx": String(UserDefaults.standard.integer(forKey: "userIdx"))
     ]
     switch self {
+      case .signin(let loginSource),
+          .signupNickname(let loginSource),
+          .signupEmail(let loginSource),
+          .signupComplete(let loginSource):
+        params["loginSource"] = loginSource.rawValue
+        
+      case .clickTab(let tabSource):
+        params["tabSource"] = tabSource.rawValue
+      
+      case .clickOpenedTravelSpot(let spot),
+          .clickClosedTravelSpot(let spot):
+        params["spot"] = spot
+    
+      case .showLoginPage(let viewSource):
+        params["viewSource"] = viewSource.rawValue
+        
+      case .clickTravelPlan(let viewSource, let postIdx):
+        params["viewSource"] = viewSource.rawValue
+        params["postIdx"] = postIdx
+        
+      case .scrapTravelPlan(let viewSource, let postIdx),
+          .scrapCancelTravelPlan(let viewSource, let postIdx):
+        params["viewSource"] = viewSource.rawValue
+        params["postIdx"] = postIdx
+        
+      case .clickPaymentMethod(let paymentSource):
+        params["paymentSource"] = paymentSource.rawValue
+      
+      case .clickPaymentButton(let postIdx),
+          .clickPlanDetailViewInPayment(let postIdx),
+          .clickAddressCopy(let postIdx):
+        params["postIdx"] = postIdx
+        
+      case .moveMapApplication(let mapSource, let postIdx):
+        params["mapSource"] = mapSource
+        params["postIdx"] = postIdx
+
+      case .clickEditorName(let viewSource, let postIdx):
+        params["viewSource"] = viewSource
+        params["postIdx"] = postIdx
 
       default: break
     }

--- a/BeMyPlan/BeMyPlan/Global/Manager/Analytics/EventType/LogEventType.swift
+++ b/BeMyPlan/BeMyPlan/Global/Manager/Analytics/EventType/LogEventType.swift
@@ -1,0 +1,122 @@
+//
+//  LogEventType.swift
+//  BeMyPlan
+//
+//  Created by 송지훈 on 2022/03/03.
+//
+
+import Foundation
+
+/**
+ 앱 설치 --> appFirstOpen
+ 앱 삭제 --> 추적 불가능
+ 
+ 로그인
+ 스크랩 눌러서 로그인
+ 구매하기 눌러서 로그인
+ 마이플랜에서 로그인
+ 
+ --> login + type
+ 
+ 
+ 메인홈 콘텐츠 보기
+ 여행지탭에 들어가 콘텐츠 리스트 보기
+ 콘텐츠 선택
+ 스크랩한 여행 일정 보기
+ -->  clickPlanDetail + case
+
+ 
+ 여행 일정 스크랩 하기
+ 여행 일정 스크랩 제거
+ --> scrap
+ 
+ 
+ 구매하기 누름
+ 결제수단 선택
+ 결제하기 누름
+ 마이플랜에서 구매한 여행 일정 누름
+
+ */
+enum LogEventType {
+  case appFirstOpen
+  case signUp
+  case clickHomePlanDetail
+  case clickSpotList
+  case clickPlanDetailInSpotList
+  
+  
+  
+  
+  case addSubjectTimetable(subjectIdx: String, subjectName: String)
+  case enterCommunicationRoom(subjectIdx: String)
+  case sendCommunicationMessage(subjectIdx: String, messageType: String)
+  case loadCommunityArticle(postIdx: String)
+  case writeCommunityArticle(boardIdx: String)
+  case writeCommunityArticleComment(postIdx: String)
+  case loadCommunityQnA(qnaIdx: String)
+  case writeCommunityQnA(tagIdx: String)
+  case writeCommunityQnaAnswer(qnaIdx: String)
+  case clickBottomTabHome
+  case clickBottomTabClass
+  case clickBottomTabCommunity
+  case clickBottomTabQna
+  case clickBottomTabMypage
+  case clickHomeMajorDept
+  case clickCommunityMajorDept
+}
+
+extension LogEventType: EventType {
+  func name(for provider: ProviderType) -> String? {
+    switch self {
+      case .appFirstOpen: return "Appsflyer_app_open"
+      case .signUp: return "Appsflyer_sign_up"
+      case .addSubjectTimetable: return "timetable_add_subject"
+      case .enterCommunicationRoom: return "lecture_entrance"
+      case .sendCommunicationMessage: return "lecture_send_message"
+      case .loadCommunityArticle: return "community_article_load"
+      case .writeCommunityArticle: return "community_article_write"
+      case .writeCommunityArticleComment: return "community_article_comment_write"
+      case .loadCommunityQnA: return "community_qna_load"
+      case .writeCommunityQnA: return "community_qna_write"
+      case .writeCommunityQnaAnswer: return "community_qna_write_answer"
+      case .clickBottomTabHome: return "event_click_bottom_tab_home"
+      case .clickBottomTabClass: return "event_click_bottom_tab_class"
+      case .clickBottomTabCommunity: return "event_click_bottom_tab_community"
+      case .clickBottomTabQna: return "event_click_bottom_tab_qna"
+      case .clickBottomTabMypage: return "event_click_bottom_tab_mypage"
+      case .clickHomeMajorDept: return "event_click_home_major_dept"
+      case .clickCommunityMajorDept: return "event_click_community_major_dept"
+    }
+  }
+  
+  func parameters(for provider: ProviderType) -> [String : Any]? {
+    var params: [String: Any] = [
+      "device": "iOS",
+      "userIdx": String(UserDefaults.standard.integer(forKey: "userIdx"))
+    ]
+    switch self {
+      case let .addSubjectTimetable(subjectIdx, subjectName):
+        params["subjectIdx"] = subjectIdx
+        params["subjectName"] = subjectName
+      case let .enterCommunicationRoom(subjectIdx):
+        params["subjectIdx"] = subjectIdx
+      case let .sendCommunicationMessage(subjectIdx, messageType):
+        params["subjectIdx"] = subjectIdx
+        params["messageType"] = messageType
+      case let .loadCommunityArticle(postIdx):
+        params["postIdx"] = postIdx
+      case let .writeCommunityArticle(boardIdx):
+        params["boardIdx"] = boardIdx
+      case let .writeCommunityArticleComment(postIdx):
+        params["postIdx"] = postIdx
+      case let .loadCommunityQnA(qnaIdx):
+        params["qnaIdx"] = qnaIdx
+      case let .writeCommunityQnA(tagIdx):
+        params["tagIdx"] = tagIdx
+      case let .writeCommunityQnaAnswer(qnaIdx):
+        params["qnaIdx"] = qnaIdx
+      default: break
+    }
+    return params
+  }
+}

--- a/BeMyPlan/BeMyPlan/Global/Manager/Analytics/EventType/LogEventType.swift
+++ b/BeMyPlan/BeMyPlan/Global/Manager/Analytics/EventType/LogEventType.swift
@@ -23,14 +23,14 @@ enum LogEventType {
   case signupEmail(source: LoginSource)
   case signupComplete(source: LoginSource)
   
-  // 5. 탭바 클릭 액션
+  // 5. 탭바 클릭 액션 O
   case clickTab(source: TabSource)
   
-  // 6. 홈탭 내 액션
+  // 6. 홈탭 내 액션 O
   case clickHomeRecentPlanList
   case clickHomeRecommendPlanList
   
-  // 7. 여행지 뷰
+  // 7. 여행지 뷰 O
   case clickOpenedTravelSpot(spot: String)
   case clickClosedTravelSpot(spot: String)
   
@@ -47,7 +47,7 @@ enum LogEventType {
   case scrapCancelTravelPlan(source: ViewSource,
                              postIdx: String)
   
-  // 11.결제 뷰
+  // 11.결제 뷰 O
   case closePaymentView
   case clickPaymentMethod(source: PaymentSource)
   case clickPaymentButton(postIdx: String)

--- a/BeMyPlan/BeMyPlan/Global/Manager/Analytics/EventType/LogEventType.swift
+++ b/BeMyPlan/BeMyPlan/Global/Manager/Analytics/EventType/LogEventType.swift
@@ -67,7 +67,7 @@ enum LogEventType {
   // 15. 작성자 이름 클릭 O
   case clickEditorName(source: ViewSource)
   
-  // 16. 회원 유입 및 이탈
+  // 16. 회원 유입 및 이탈 O
   case enterForeGround
   case enterBackGround
   case logout

--- a/BeMyPlan/BeMyPlan/Global/Manager/Analytics/FirebaseServiceProtocol.swift
+++ b/BeMyPlan/BeMyPlan/Global/Manager/Analytics/FirebaseServiceProtocol.swift
@@ -1,0 +1,30 @@
+//
+//  FirebaseServiceProtocol.swift
+//  BeMyPlan
+//
+//  Created by 송지훈 on 2022/03/03.
+//
+
+import Foundation
+import FirebaseCore
+import FirebaseAnalytics
+import FirebaseCrashlytics
+
+protocol FirebaseConfigureServiceProtocol: AnyObject {
+  static func configure()
+}
+
+protocol FirebaseAnalyticsServiceProtocol: AnyObject {
+  static func logEvent(_ name: String, parameters: [String: Any]?)
+  static func setUserProperty(_ value: String?, forName name: String)
+  static func setUserID(_ userID: String?)
+  static func resetAnalyticsData()
+}
+
+protocol CrashlyticsServiceProtocol: AnyObject {
+  static func crashlytics() -> Self
+}
+
+extension FirebaseApp: FirebaseConfigureServiceProtocol {}
+extension Analytics: FirebaseAnalyticsServiceProtocol {}
+extension Crashlytics: CrashlyticsServiceProtocol {}

--- a/BeMyPlan/BeMyPlan/Global/Manager/Analytics/Provider/FirebaseAnalyticsProvider.swift
+++ b/BeMyPlan/BeMyPlan/Global/Manager/Analytics/Provider/FirebaseAnalyticsProvider.swift
@@ -1,0 +1,16 @@
+//
+//  FirebaseAnalyticsProvider.swift
+//  BeMyPlan
+//
+//  Created by 송지훈 on 2022/03/03.
+//
+
+import FirebaseCore
+import FirebaseAnalytics
+
+open class FirebaseAnalyticsProvider: RuntimeProviderType {
+  public let className: String = "FIRAnalytics"
+  public let selectorName: String = "logEventWithName:parameters:"
+
+  public init() {}
+}

--- a/BeMyPlan/BeMyPlan/Global/Manager/Analytics/Provider/RuntimeProviderType.swift
+++ b/BeMyPlan/BeMyPlan/Global/Manager/Analytics/Provider/RuntimeProviderType.swift
@@ -1,0 +1,53 @@
+//
+//  RuntimeProviderType.swift
+//  BeMyPlan
+//
+//  Created by 송지훈 on 2022/03/03.
+//
+
+import Foundation
+
+public protocol RuntimeProviderType: ProviderType {
+  var className: String { get }
+  var instanceSelectorName: String? { get } // optional
+  var selectorName: String { get }
+}
+
+public extension RuntimeProviderType {
+  var cls: NSObject.Type? {
+    return NSClassFromString(self.className) as? NSObject.Type
+  }
+
+  var instanceSelectorName: String? {
+    return nil
+  }
+
+  var instance: AnyObject? {
+    guard let cls = self.cls else { return nil }
+    guard let sel = self.instanceSelectorName.flatMap(NSSelectorFromString) else { return nil }
+    guard cls.responds(to: sel) else { return nil }
+    return cls.perform(sel)?.takeUnretainedValue()
+  }
+
+  var selector: Selector {
+    return NSSelectorFromString(self.selectorName)
+  }
+
+  var responds: Bool {
+    guard let cls = self.cls else { return false }
+    if let instance = self.instance {
+      return instance.responds(to: self.selector)
+    } else {
+      return cls.responds(to: self.selector)
+    }
+  }
+
+  func log(_ eventName: String, parameters: [String: Any]?) {
+    guard self.responds else { return }
+    if let instance = self.instance {
+      _ = instance.perform(self.selector, with: eventName, with: parameters)
+    } else {
+      _ = self.cls?.perform(self.selector, with: eventName, with: parameters)
+    }
+  }
+}

--- a/BeMyPlan/BeMyPlan/Global/Supporting Files/AppDelegate.swift
+++ b/BeMyPlan/BeMyPlan/Global/Supporting Files/AppDelegate.swift
@@ -37,6 +37,14 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     // If any sessions were discarded while the application was not running, this will be called shortly after application:didFinishLaunchingWithOptions.
     // Use this method to release any resources that were specific to the discarded scenes, as they will not return.
   }
+  
+  
+  func applicationDidBecomeActive(_ application: UIApplication) {
+    if UserDefaults.standard.bool(forKey: "isFirstOpen") == false {
+      AppLog.log(at: FirebaseAnalyticsProvider.self, .appFirstOpen)
+      UserDefaults.standard.set(true, forKey: "isFirstOpen")
+    }
+  }
 }
 
 extension AppDelegate{

--- a/BeMyPlan/BeMyPlan/Global/Supporting Files/AppDelegate.swift
+++ b/BeMyPlan/BeMyPlan/Global/Supporting Files/AppDelegate.swift
@@ -19,7 +19,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
   
   func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
     // Override point for customization after application launch.
-    FirebaseApp.configure()
+    setupFirebaseSDK()
     KakaoSDK.initSDK(appKey: "904d52aff326e5526e945eee5dfb8efd")
     return true
   }
@@ -36,5 +36,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     // Called when the user discards a scene session.
     // If any sessions were discarded while the application was not running, this will be called shortly after application:didFinishLaunchingWithOptions.
     // Use this method to release any resources that were specific to the discarded scenes, as they will not return.
+  }
+}
+
+extension AppDelegate{
+  func setupFirebaseSDK() {
+    AppLog.configure()
   }
 }

--- a/BeMyPlan/BeMyPlan/Screen/Base/BaseVC.swift
+++ b/BeMyPlan/BeMyPlan/Screen/Base/BaseVC.swift
@@ -16,7 +16,10 @@ class BaseVC: UIViewController {
   // MARK: - Vars & Lets Part
   var isFirstload = true
   var clickedIndex : TabList = .home{
-    didSet{ runTabClickAction() }
+    didSet{
+      runTabClickAction()
+      setTabLog()
+    }
   }
   var currentTabList : [TabList] = []
   let factory: ModuleFactoryProtocol = ModuleFactory.resolve()
@@ -87,6 +90,17 @@ class BaseVC: UIViewController {
         currentTabList.append(clickedIndex)
       }
     }
+  }
+  
+  private func setTabLog(){
+    let tabSource: LogEventType.TabSource
+    switch(clickedIndex){
+      case .home: tabSource = .home
+      case .travelSpot: tabSource = .travelSpot
+      case .scrap: tabSource = .scrap
+      case .myPlan: tabSource = .myPlan
+    }
+    AppLog.log(at: FirebaseAnalyticsProvider.self, .clickTab(source: tabSource))
   }
   private func showContainerView(){
     self.containerView.alpha = 1

--- a/BeMyPlan/BeMyPlan/Screen/Base/Notification/BaseVC + Notification.swift
+++ b/BeMyPlan/BeMyPlan/Screen/Base/Notification/BaseVC + Notification.swift
@@ -127,8 +127,16 @@ extension BaseVC{
       self.tabClicked(index: .home)
     }
     
-    NotificationCenter.default.addObserver(forName: UIApplication.willResignActiveNotification) { _ in
+    NotificationCenter.default.addObserver(forName: UIApplication.willResignActiveNotification,
+                                           object: nil,
+                                           queue: nil) { _ in
       AppLog.log(at: FirebaseAnalyticsProvider.self, .enterBackGround)
+    }
+    
+    NotificationCenter.default.addObserver(forName: UIApplication.willEnterForegroundNotification,
+                                           object: nil,
+                                           queue: nil) { _ in
+      AppLog.log(at: FirebaseAnalyticsProvider.self, .enterForeGround)
     }
     
   }

--- a/BeMyPlan/BeMyPlan/Screen/Base/Notification/BaseVC + Notification.swift
+++ b/BeMyPlan/BeMyPlan/Screen/Base/Notification/BaseVC + Notification.swift
@@ -127,5 +127,10 @@ extension BaseVC{
       self.tabClicked(index: .home)
     }
     
+    NotificationCenter.default.addObserver(forName: UIApplication.willResignActiveNotification) { _ in
+      AppLog.log(at: FirebaseAnalyticsProvider.self, .enterBackGround)
+    }
+    
   }
+  
 }

--- a/BeMyPlan/BeMyPlan/Screen/Home/MainCard/MainCardView.swift
+++ b/BeMyPlan/BeMyPlan/Screen/Home/MainCard/MainCardView.swift
@@ -169,6 +169,8 @@ class MainCardView: UIView {
 
 extension MainCardView : SkeletonCollectionViewDelegate{
   func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+    AppLog.log(at: FirebaseAnalyticsProvider.self, .clickTravelPlan(source: .homeView,
+                                                                    postIdx:  String(popularList[indexPath.row].id)))
     postObserverAction(.movePlanPreview,object: popularList[indexPath.row].id)
   }
 }

--- a/BeMyPlan/BeMyPlan/Screen/Home/MainList/MainListView.swift
+++ b/BeMyPlan/BeMyPlan/Screen/Home/MainList/MainListView.swift
@@ -169,6 +169,8 @@ class MainListView: UIView {
 
 extension MainListView : SkeletonCollectionViewDelegate{
   func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+    AppLog.log(at: FirebaseAnalyticsProvider.self, .clickTravelPlan(source: .homeView,
+                                                                    postIdx:  String(mainListDataList[indexPath.row].id)))
     postObserverAction(.movePlanPreview,object: mainListDataList[indexPath.row].id)
   }
 }

--- a/BeMyPlan/BeMyPlan/Screen/Home/MainList/MainListView.swift
+++ b/BeMyPlan/BeMyPlan/Screen/Home/MainList/MainListView.swift
@@ -73,7 +73,13 @@ class MainListView: UIView {
   
   @IBAction func touchUpToPlanList(_ sender: Any) {
     var detailCase : TravelSpotDetailType = .new
-    type == .recently ? (detailCase = .new) : (detailCase = .suggest)
+    if type == .recently {
+      detailCase = .new
+      AppLog.log(at: FirebaseAnalyticsProvider.self, .clickHomeRecentPlanList)
+    }else {
+      detailCase = .suggest
+      AppLog.log(at: FirebaseAnalyticsProvider.self, .clickHomeRecommendPlanList)
+    }
     postObserverAction(.moveHomeToPlanList,object: detailCase)
   }
   

--- a/BeMyPlan/BeMyPlan/Screen/MyPlan/BuyList/MyPlanVC.swift
+++ b/BeMyPlan/BeMyPlan/Screen/MyPlan/BuyList/MyPlanVC.swift
@@ -71,6 +71,8 @@ class MyPlanVC: UIViewController {
 extension MyPlanVC :UICollectionViewDelegate{
   
   func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+    AppLog.log(at: FirebaseAnalyticsProvider.self, .clickTravelPlan(source: .myPlanView,
+                                                                    postIdx:  String(buyContentList[indexPath.row].id)))
     postObserverAction(.movePlanDetail,object: buyContentList[indexPath.row].id)
   }
   func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, referenceSizeForHeaderInSection section: Int) -> CGSize {

--- a/BeMyPlan/BeMyPlan/Screen/MyPlan/Setting/MyPlanSettingVC.swift
+++ b/BeMyPlan/BeMyPlan/Screen/MyPlan/Setting/MyPlanSettingVC.swift
@@ -74,6 +74,7 @@ class MyPlanSettingVC: UIViewController, MFMailComposeViewControllerDelegate {
             guard let loginVC = UIStoryboard.list(.login).instantiateViewController(withIdentifier: LoginNC.className) as? LoginNC else {return}
             loginVC
               .modalPresentationStyle = .fullScreen
+            AppLog.log(at: FirebaseAnalyticsProvider.self, .logout)
             self.present(loginVC, animated: false, completion: nil)
           }
         }

--- a/BeMyPlan/BeMyPlan/Screen/MyPlan/WithDraw/MyPlanWithdrawVC.swift
+++ b/BeMyPlan/BeMyPlan/Screen/MyPlan/WithDraw/MyPlanWithdrawVC.swift
@@ -59,6 +59,7 @@ class MyPlanWithdrawVC: UIViewController {
         self.withdrawAction { result in
           if result{
             self.makeAlert(alertCase: .simpleAlert, title: "탈퇴하기", content: "탈퇴 완료되었습니다.") {
+              AppLog.log(at: FirebaseAnalyticsProvider.self, .withdrawal)
               guard let loginVC = UIStoryboard.list(.login).instantiateViewController(withIdentifier: LoginNC.className) as? LoginNC else {return}
               loginVC
                 .modalPresentationStyle = .fullScreen

--- a/BeMyPlan/BeMyPlan/Screen/Payment/PaymentCompleteVC.swift
+++ b/BeMyPlan/BeMyPlan/Screen/Payment/PaymentCompleteVC.swift
@@ -10,6 +10,7 @@ class PaymentCompleteVC: UIViewController {
   
   // MARK: - Var,Let Parts
   
+  var postIdx: Int = 0
   var writer : String = ""
   var planTitle : String = ""
   var delegate : PaymentCompleteDelegate?
@@ -42,10 +43,12 @@ class PaymentCompleteVC: UIViewController {
   }
 
   @IBAction func closeButtonClicked(_ sender: Any) {
+    AppLog.log(at: FirebaseAnalyticsProvider.self, .closePaymentCompleteView)
     self.dismiss(animated: true, completion: nil)
   }
   
   @IBAction func showContentButtonClicked(_ sender: Any) {
+    AppLog.log(at: FirebaseAnalyticsProvider.self, .clickPlanDetailViewInPayment(postIdx: String(postIdx)))
     dismiss(animated: true) {
       self.delegate?.completeButtonClicked()
     }

--- a/BeMyPlan/BeMyPlan/Screen/Payment/PaymentSelectVC.swift
+++ b/BeMyPlan/BeMyPlan/Screen/Payment/PaymentSelectVC.swift
@@ -20,6 +20,7 @@ class PaymentSelectVC: UIViewController {
       if selectedIndex == -1{
         paymentButton.tintColor = .grey04
       }else{
+        setPaymentLog()
         paymentButton.backgroundColor = .bemyBlue
       }
       setButtonState()
@@ -54,6 +55,7 @@ class PaymentSelectVC: UIViewController {
   // MARK: - Custom Method Part
 
   @IBAction func backButtonClicked(_ sender: Any) {
+    AppLog.log(at: FirebaseAnalyticsProvider.self, .closePaymentView)
     self.navigationController?.popViewController(animated: true)
   }
   
@@ -67,6 +69,8 @@ class PaymentSelectVC: UIViewController {
       paymentCompleteVC.paymentType = paymentList[selectedIndex]
       paymentCompleteVC.planTitle = planTitle ?? ""
       paymentCompleteVC.writer = writer ?? ""
+      paymentCompleteVC.postIdx = postIdx
+      AppLog.log(at: FirebaseAnalyticsProvider.self, .clickPaymentButton(postIdx: String(postIdx)))
       present(paymentCompleteVC,animated: true)
     }
  
@@ -86,6 +90,16 @@ class PaymentSelectVC: UIViewController {
     
   }
   
+  private func setPaymentLog(){
+    let paymentSource :LogEventType.PaymentSource
+    switch(selectedIndex) {
+      case 0: paymentSource = .kakaoPay
+      case 1: paymentSource = .toss
+      default: paymentSource = .naverPay
+    }
+    AppLog.log(at: FirebaseAnalyticsProvider.self, .clickPaymentMethod(source: paymentSource))
+  }
+  
   private func setPriceLabel(){
     moneyLabel.text = price
   }
@@ -94,6 +108,7 @@ class PaymentSelectVC: UIViewController {
     for (index,item) in paymentButtonList.enumerated(){
       item.setButtonState(isSelected: false)
       item.press(animated: true) {
+        
         self.selectedIndex = index
       }
     }

--- a/BeMyPlan/BeMyPlan/Screen/Plan/PlanDetail/Cells/0-Writer/PlanDetailWriterContainerView.swift
+++ b/BeMyPlan/BeMyPlan/Screen/Plan/PlanDetail/Cells/0-Writer/PlanDetailWriterContainerView.swift
@@ -55,6 +55,7 @@ class PlanDetailWriterContainerView: XibView {
   @IBAction func nicknameButtonClicked(_ sender: Any) {
     let data = PlanWriterDataModel.init(authorName: viewModel.nickname,
                                         authorID: viewModel.authID)
+    AppLog.log(at: FirebaseAnalyticsProvider.self, .clickEditorName(source: .planDetail))
     postObserverAction(.moveNicknamePlanList, object: data)
   }
   

--- a/BeMyPlan/BeMyPlan/Screen/Plan/PlanDetail/Cells/1-Map/PlanDetailMapContainerView.swift
+++ b/BeMyPlan/BeMyPlan/Screen/Plan/PlanDetail/Cells/1-Map/PlanDetailMapContainerView.swift
@@ -181,13 +181,16 @@ class PlanDetailMapContainerView: XibView,MTMapViewDelegate{
     let searchURL = makeMapsURL(place: place, platform: .kakao)
     if let appUrl = searchURL{
       if(UIApplication.shared.canOpenURL(appUrl)){
+        AppLog.log(at: FirebaseAnalyticsProvider.self, .moveMapApplication(source: .kakaoMap))
         UIApplication.shared.open(appUrl, options: [:], completionHandler: nil)
       }else{
         let searchURL = makeMapsURL(place: place, platform: .naver)
         if let appUrl = searchURL{
           if(UIApplication.shared.canOpenURL(appUrl)){
+            AppLog.log(at: FirebaseAnalyticsProvider.self, .moveMapApplication(source: .naverMap))
             UIApplication.shared.open(appUrl, options: [:], completionHandler: nil)
           }else{
+            AppLog.log(at: FirebaseAnalyticsProvider.self, .alertNoMapApplication)
             postObserverAction(.showNotInstallKakaomap)
           }
         }

--- a/BeMyPlan/BeMyPlan/Screen/Plan/PlanDetail/Cells/4-Information/PlanDetailInformationTVC.swift
+++ b/BeMyPlan/BeMyPlan/Screen/Plan/PlanDetail/Cells/4-Information/PlanDetailInformationTVC.swift
@@ -94,6 +94,8 @@ class PlanDetailInformationTVC: UITableViewCell,UITableViewRegisterable {
   
   // MARK: - IBActions Part
   @IBAction func addressCopyButtonClicked(_ sender: Any) {
+    AppLog.log(at: FirebaseAnalyticsProvider.self, .clickAddressCopy)
+
     UIPasteboard.general.string = viewModel.address
     postObserverAction(.copyComplete)
   }

--- a/BeMyPlan/BeMyPlan/Screen/Plan/PlanPreview/Cells/PlanPreviewWriterTVC.swift
+++ b/BeMyPlan/BeMyPlan/Screen/Plan/PlanPreview/Cells/PlanPreviewWriterTVC.swift
@@ -39,6 +39,7 @@ class PlanPreviewWriterTVC: UITableViewCell,UITableViewRegisterable{
   @IBAction func nicknameButtonClicked(_ sender: Any) {
     let data = PlanWriterDataModel.init(authorName: nickname,
                                         authorID: authID)
+    AppLog.log(at: FirebaseAnalyticsProvider.self, .clickEditorName(source: .planPreview))
     postObserverAction(.moveNicknamePlanList,object: data)
   }
   

--- a/BeMyPlan/BeMyPlan/Screen/Plan/PlanPreview/PlanPreviewVC.swift
+++ b/BeMyPlan/BeMyPlan/Screen/Plan/PlanPreview/PlanPreviewVC.swift
@@ -95,6 +95,7 @@ class PlanPreviewVC: UIViewController {
     }
     
     viewModel.movePreviewDetailView = { [weak self] in
+      AppLog.log(at: FirebaseAnalyticsProvider.self, .clickPlanDetailExample)
       guard let self = self else {return}
       let vc = ModuleFactory.resolve().instantiatePlanDetailVC(postID: self.viewModel.postId, isPreviewPage: true)
       self.navigationController?.pushViewController(vc, animated: true)

--- a/BeMyPlan/BeMyPlan/Screen/Scrap/ScrapEmptyVC/ScrapEmptyContainerView.swift
+++ b/BeMyPlan/BeMyPlan/Screen/Scrap/ScrapEmptyVC/ScrapEmptyContainerView.swift
@@ -100,7 +100,9 @@ extension ScrapEmptyContainerView: UICollectionViewDataSource {
 
 extension ScrapEmptyContainerView : UICollectionViewDelegate{
   func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-    postObserverAction(.movePlanPreview)
+    AppLog.log(at: FirebaseAnalyticsProvider.self, .clickTravelPlan(source: .scrapRecommendView,
+                                                                    postIdx:  String(contentDataList[indexPath.row].postID)))
+    postObserverAction(.movePlanPreview,object: contentDataList[indexPath.row].postID)
   }
 }
 

--- a/BeMyPlan/BeMyPlan/Screen/Scrap/ScrapVC/ScrapContainerView.swift
+++ b/BeMyPlan/BeMyPlan/Screen/Scrap/ScrapVC/ScrapContainerView.swift
@@ -95,6 +95,8 @@ extension ScrapContainerView: UICollectionViewDataSource {
 
 extension ScrapContainerView: UICollectionViewDelegate{
   func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+    AppLog.log(at: FirebaseAnalyticsProvider.self, .clickTravelPlan(source: .scrapView,
+                                                                    postIdx:  String(scrapDataList[indexPath.row].postID)))
     postObserverAction(.movePlanPreview,object: scrapDataList[indexPath.row].postID)
   }
 }

--- a/BeMyPlan/BeMyPlan/Screen/Splash/SplashVC.swift
+++ b/BeMyPlan/BeMyPlan/Screen/Splash/SplashVC.swift
@@ -22,6 +22,8 @@ class SplashVC: UIViewController {
   
   override func viewDidLoad() {
     super.viewDidLoad()
+    UserDefaults.standard.setValue(100, forKey: "userIdx")
+    AppLog.setFirebaseUserProperty()
     startSplash()
   }
   

--- a/BeMyPlan/BeMyPlan/Screen/TravelSpot/TravelSpotDetailVC.swift
+++ b/BeMyPlan/BeMyPlan/Screen/TravelSpot/TravelSpotDetailVC.swift
@@ -199,6 +199,8 @@ extension TravelSpotDetailVC: UITableViewDelegate {
   }
   
   func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+    AppLog.log(at: FirebaseAnalyticsProvider.self, .clickTravelPlan(source: .planListView,
+                                                                    postIdx:  String(planDataList[indexPath.row].id)))
     postObserverAction(.movePlanPreview,object: planDataList[indexPath.row].id)
   }
 }

--- a/BeMyPlan/BeMyPlan/Screen/TravelSpot/TravelSpotVC.swift
+++ b/BeMyPlan/BeMyPlan/Screen/TravelSpot/TravelSpotVC.swift
@@ -89,6 +89,9 @@ extension TravelSpotVC: UICollectionViewDelegate {
     //    self.navigationController?.popViewController(animated: true)
     if travelSpotDataList[indexPath.row].isActivated {
       postObserverAction(.movePlanList,object: travelSpotDataList[indexPath.row].id)
+      AppLog.log(at: FirebaseAnalyticsProvider.self, .clickOpenedTravelSpot(spot: travelSpotDataList[indexPath.row].name))
+    }else{
+      AppLog.log(at: FirebaseAnalyticsProvider.self, .clickClosedTravelSpot(spot: travelSpotDataList[indexPath.row].name))
     }
   }
 }


### PR DESCRIPTION
## ✨ 작업 내용 
- [x] 추후 유저 행동을 트래킹하기 위해 이벤트 로그를 다 심어뒀습니다!
- [x] 현재 없는 기능에 대해서는 추가하지 않고, 있는 곳에는 다 심어둔 상태입니다!

(로그 목록)

0 . 앱 실행
 앱 최초 실행
1 . 온보딩 (온보딩 완성된다면?)
온보딩 최초로 보기
온보딩 완료
2 - 로그인
Apple Login(Google Login) 클릭
카카오 Login 클릭
둘러보기 클릭
3 - 회원가입
닉네임 입력후 다음 클릭
이메일 입력후 다음 클릭
회원가입 완료
4 - 하단 탭바 액션
홈 탭 누르기
여행지 탭 누르기
스크랩 탭 누르기
마이플랜 탭 누르기
5 - 홈 뷰
홈에서 최신여행일정 자세히 보기 클릭
홈에서 에디터 추천 여행일정 클릭
6 - 여행지뷰
열려있는 여행지 클릭
닫혀있는 여행지 클릭
7 - 둘러보기 상태에서 로그인 창 띄우는 경로
스크랩 -> 로그인 뷰
구매하기 -> 로그인 뷰
마이플랜 -> 로그인 뷰
8 - 여행 일정 클릭
 홈에서 여행 일정 클릭
여행지 목록에서 여행 일정 클릭
스크랩 목록에서 여행 일정 클릭
구매 목록에서 여행 일정 클릭
9 - 스크랩 액션
스크랩 하기 + 어느뷰에서 했는지 (여행지 목록,구매전 뷰)
스크랩 취소 + 어느 뷰에서 했는지(스크랩탭, 여행지 목록,구매전 뷰)
10 - 결제 뷰
결제 수단(카카오페이,토스,네이버페이) 선택
결제하기 클릭
11 - 결제 완료 뷰
 결제 완료 창에서 콘텐츠 보러가기 클릭
 결제 완료 창에서 창 닫기 클릭
12 - (결제전) 여행 일정 화면
작성자 이름 클릭
구매한 여행 일정 예시 클릭
13 - (결제후) 여행 일정 화면
주소 복사 클릭
여행지 말풍선 클릭
작성자 이름 클릭
14 - 회원 이탈
 로그아웃
앱 종료(홈으로 나가기)
 회원탈퇴 (아직 탈퇴없으니까 대기)



